### PR TITLE
Shape Tool Key Bindings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,25 +32,10 @@ export default class App extends Vue {
         this.$store.commit("activeSlide", this.$store.getters.firstSlide.id);
 
         document.addEventListener("keydown", (event: KeyboardEvent) => {
-            const isPressed: boolean = this.$store.getters.pressedKeys[event.keyCode];
-            const DELETE_KEY_CODE: number = 46, BACKSPACE_KEY_CODE: number = 8;
-
-            if (!isPressed) {
-                this.$store.commit("pressedKeys", { keyCode: event.keyCode, isPressed: true });
-            }
-
-            if (event.keyCode === DELETE_KEY_CODE || event.keyCode === BACKSPACE_KEY_CODE) {
+            if (event.key === "Delete" || event.key === "Backspace") {
                 this.$store.commit("removeGraphic", { slideId: this.$store.getters.activeSlide.id, graphicId: this.$store.getters.focusedGraphicId });
                 this.$store.commit("focusGraphic", undefined);
                 this.$store.commit("styleEditorObject", undefined);
-            }
-        });
-
-        document.addEventListener("keyup", (event: KeyboardEvent) => {
-            const isPressed: boolean = this.$store.getters.pressedKeys[event.keyCode];
-
-            if (isPressed) {
-                this.$store.commit("pressedKeys", { keyCode: event.keyCode, isPressed: false });
             }
         });
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -52,7 +52,6 @@ export default new Vuex.Store({
             ellipse: Tools.ellipseTool,
             textbox: Tools.textboxTool
         } as { [key: string]: ToolModel },
-        pressedKeys: { } as { [key: number]: boolean },
         toolbox: {
             width: 72
         }
@@ -87,9 +86,6 @@ export default new Vuex.Store({
         },
         tool: (state: any): ToolModel => {
             return state.tools[state.currentTool];
-        },
-        pressedKeys: (state: any): any => {
-            return state.pressedKeys;
         },
         toolboxWidth: (state: any): number => {
             return state.toolbox.width;
@@ -155,9 +151,6 @@ export default new Vuex.Store({
         },
         activeSlide: (state: any, slideId: string): void => {
             state.activeSlideId = slideId;
-        },
-        pressedKeys: (state: any, { keyCode, isPressed }: { keyCode: number, isPressed: boolean }): void => {
-            state.pressedKeys[keyCode] = isPressed;
         },
         focusGraphic: (state: any, graphic?: GraphicModel): void => {
             state.focusedGraphicId = graphic === undefined ? undefined : graphic.id;


### PR DESCRIPTION
This pull request modifies the key bindings when drawing. In this case, pressing `shift` while drawing a rectangle or ellipse now immediately changes the shape to a square or circle, respectively.