### PR TITLE
[058] Snappable Vectors

### DIFF
--- a/src/models/SnapVector.ts
+++ b/src/models/SnapVector.ts
@@ -14,17 +14,10 @@ export default class SnapVector {
     // Calculates the distance between the given point and the line represented by the SnapVector
     // If the SnapVector has no direction than it returns a simple point-to-point distance
     public distanceFromVector(point: Vector): number {
-        const difference: Vector = point.add(this.origin.scale(-1));
+        return point.towards(this.getClosestPoint(point)).magnitude;
+    }
 
-        if (this.direction.equals(Vector.zero)) {
-            return difference.magnitude;
-        }
-
-        if (this.direction.equals(Vector.up) || this.direction.equals(Vector.down)) {
-            return Math.abs(this.origin.x - point.x);
-        }
-
-        const standardForm: Vector = new Vector(-this.direction.y / this.direction.x, 1);
-        return Math.abs(standardForm.x * difference.x + standardForm.y * difference.y) / standardForm.magnitude;
+    public getClosestPoint(point: Vector): Vector {
+        return this.origin.add(this.origin.towards(point).projectOn(this.direction));
     }
 }

--- a/src/models/SnapVector.ts
+++ b/src/models/SnapVector.ts
@@ -20,6 +20,10 @@ export default class SnapVector {
             return difference.magnitude;
         }
 
+        if (this.direction.equals(Vector.up) || this.direction.equals(Vector.down)) {
+            return Math.abs(this.origin.x - point.x);
+        }
+
         const standardForm: Vector = new Vector(-this.direction.y / this.direction.x, 1);
         return Math.abs(standardForm.x * difference.x + standardForm.y * difference.y) / standardForm.magnitude;
     }

--- a/src/models/Vector.ts
+++ b/src/models/Vector.ts
@@ -22,12 +22,32 @@ export default class Vector {
         return this.magnitude === 0 ? Vector.zero : new Vector(this.x / this.magnitude, this.y / this.magnitude);
     }
 
+    get array(): Array<number> {
+        return [this.x, this.y];
+    }
+
     public toArray(): Array<number> {
         return [this.x, this.y];
     }
 
-    public add(point: Vector): Vector {
-        return new Vector(this.x + point.x, this.y + point.y);
+    public add(vector: Vector): Vector {
+        return new Vector(this.x + vector.x, this.y + vector.y);
+    }
+
+    public towards(vector: Vector): Vector {
+        return vector.add(this.scale(-1));
+    }
+
+    public dot(vector: Vector): number {
+        return this.x * vector.x + this.y * vector.y;
+    }
+
+    public theta(vector: Vector): number {
+        return Math.acos(this.dot(vector) / (this.magnitude * vector.magnitude));
+    }
+
+    public projectOn(vector: Vector): Vector {
+        return vector.normalized.scale(this.dot(vector.normalized));
     }
 
     public scale(scalar: number): Vector {
@@ -35,7 +55,7 @@ export default class Vector {
     }
 
     public reflect(origin: Vector = this): Vector {
-        return origin.scale(2).add(this.scale(-1));
+        return origin.add(origin.towards(this).scale(-1));
     }
 
     public transform(transformation: (coordinate: number) => number) {

--- a/src/models/graphics/Curve.ts
+++ b/src/models/graphics/Curve.ts
@@ -60,25 +60,22 @@ export default class Curve implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
-        const boundingBox: SVG.RBox = svg.rbox();
-        const width: number = boundingBox.width;
-        const height: number = boundingBox.height;
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, this.origin, Vector.right));
+        snapVectors.push(new SnapVector(this.id, this.origin, Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(this.origin);
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/Curve.ts
+++ b/src/models/graphics/Curve.ts
@@ -76,4 +76,8 @@ export default class Curve implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.Path): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Curve.ts
+++ b/src/models/graphics/Curve.ts
@@ -60,8 +60,9 @@ export default class Curve implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Path): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
         const boundingBox: SVG.RBox = svg.rbox();
         const width: number = boundingBox.width;
         const height: number = boundingBox.height;
@@ -77,7 +78,7 @@ export default class Curve implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Path): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Ellipse.ts
+++ b/src/models/graphics/Ellipse.ts
@@ -50,8 +50,9 @@ export default class Ellipse implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Ellipse): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
         snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
@@ -64,7 +65,7 @@ export default class Ellipse implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Ellipse): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Ellipse.ts
+++ b/src/models/graphics/Ellipse.ts
@@ -63,4 +63,8 @@ export default class Ellipse implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.Ellipse): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Ellipse.ts
+++ b/src/models/graphics/Ellipse.ts
@@ -50,22 +50,30 @@ export default class Ellipse implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y),                     Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width,     this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height),       Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x,                  this.origin.y + this.height / 2),   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y + this.height));
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y + this.height / 2));
+        snappableVectors.push(new Vector(this.origin.x + this.width / 2,    this.origin.y + this.height / 2));
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/IGraphic.ts
+++ b/src/models/graphics/IGraphic.ts
@@ -10,6 +10,6 @@ export default interface IGraphic {
     boundingBoxId: string;
     render(canvas: SVG.Doc): SVG.Element;
     updateRendering(svg: SVG.Element): void;
-    getSnapVectors(origin: Vector): Array<SnapVector>;
-    getSnappableVectors(origin: Vector): Array<Vector>;
+    getSnapVectors(): Array<SnapVector>;
+    getSnappableVectors(): Array<Vector>;
 }

--- a/src/models/graphics/IGraphic.ts
+++ b/src/models/graphics/IGraphic.ts
@@ -10,6 +10,6 @@ export default interface IGraphic {
     boundingBoxId: string;
     render(canvas: SVG.Doc): SVG.Element;
     updateRendering(svg: SVG.Element): void;
-    getSnapVectors(svg: SVG.Element): Array<SnapVector>;
-    getSnappableVectors(svg: SVG.Element): Array<Vector>;
+    getSnapVectors(origin: Vector): Array<SnapVector>;
+    getSnappableVectors(origin: Vector): Array<Vector>;
 }

--- a/src/models/graphics/IGraphic.ts
+++ b/src/models/graphics/IGraphic.ts
@@ -11,4 +11,5 @@ export default interface IGraphic {
     render(canvas: SVG.Doc): SVG.Element;
     updateRendering(svg: SVG.Element): void;
     getSnapVectors(svg: SVG.Element): Array<SnapVector>;
+    getSnappableVectors(svg: SVG.Element): Array<Vector>;
 }

--- a/src/models/graphics/Image.ts
+++ b/src/models/graphics/Image.ts
@@ -56,4 +56,8 @@ export default class Image implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.Image): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Image.ts
+++ b/src/models/graphics/Image.ts
@@ -43,8 +43,9 @@ export default class Image implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Image): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
         snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
@@ -57,7 +58,7 @@ export default class Image implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Image): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Image.ts
+++ b/src/models/graphics/Image.ts
@@ -43,22 +43,30 @@ export default class Image implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y),                     Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width,     this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height),       Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x,                  this.origin.y + this.height / 2),   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y + this.height));
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y + this.height / 2));
+        snappableVectors.push(new Vector(this.origin.x + this.width / 2,    this.origin.y + this.height / 2));
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/Rectangle.ts
+++ b/src/models/graphics/Rectangle.ts
@@ -65,6 +65,15 @@ export default class Rectangle implements IGraphic {
     }
 
     public getSnappableVectors(svg: SVG.Rect): Array<Vector> {
-        return [];
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height / 2), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, 0), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width, this.height / 2), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height), svg));
+        snappableVectors.push(Utilities.transform(new Vector(0, this.height / 2), svg));
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/Rectangle.ts
+++ b/src/models/graphics/Rectangle.ts
@@ -50,29 +50,29 @@ export default class Rectangle implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height / 2),    Vector.right));
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height / 2),    Vector.up));
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y),                      Vector.right));
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width,      origin.y + this.height / 2),    Vector.up));
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height),        Vector.right));
-        snapVectors.push(new SnapVector(this.id, new Vector(origin.x,                   origin.y + this.height / 2),    Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y),                     Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width,     this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height),       Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x,                  this.origin.y + this.height / 2),   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
+    public getSnappableVectors(): Array<Vector> {
         const snappableVectors: Array<Vector> = [];
 
         // Center, upper center, left center, lower center, right center
-        snappableVectors.push(new Vector(origin.x, origin.y));
-        snappableVectors.push(new Vector(origin.x + this.width, origin.y));
-        snappableVectors.push(new Vector(origin.x + this.width, origin.y + this.height));
-        snappableVectors.push(new Vector(origin.x, origin.y + this.height / 2));
-        snappableVectors.push(new Vector(origin.x + this.width / 2, origin.y + this.height / 2));
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y + this.height));
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y + this.height / 2));
+        snappableVectors.push(new Vector(this.origin.x + this.width / 2,    this.origin.y + this.height / 2));
 
         return snappableVectors;
     }

--- a/src/models/graphics/Rectangle.ts
+++ b/src/models/graphics/Rectangle.ts
@@ -55,12 +55,16 @@ export default class Rectangle implements IGraphic {
 
         // Center, upper center, left center, lower center, right center
         snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
-        // snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
-        // snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
-        // snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
-        // snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
-        // snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
+        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
+        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
 
         return snapVectors;
+    }
+
+    public getSnappableVectors(svg: SVG.Rect): Array<Vector> {
+        return [];
     }
 }

--- a/src/models/graphics/Rectangle.ts
+++ b/src/models/graphics/Rectangle.ts
@@ -50,7 +50,7 @@ export default class Rectangle implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Rect): Array<SnapVector> {
+    public getSnapVectors(svg: SVG.Element): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
 
         // Center, upper center, left center, lower center, right center
@@ -68,11 +68,11 @@ export default class Rectangle implements IGraphic {
         const snappableVectors: Array<Vector> = [];
 
         // Center, upper center, left center, lower center, right center
-        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height / 2), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, 0), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width, this.height / 2), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height), svg));
+        snappableVectors.push(Utilities.transform(new Vector(0, 0), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width, 0), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width, this.height), svg));
         snappableVectors.push(Utilities.transform(new Vector(0, this.height / 2), svg));
+        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height / 2), svg));
 
         return snappableVectors;
     }

--- a/src/models/graphics/Rectangle.ts
+++ b/src/models/graphics/Rectangle.ts
@@ -50,29 +50,29 @@ export default class Rectangle implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Element): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height / 2),    Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height / 2),    Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y),                      Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width,      origin.y + this.height / 2),    Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x + this.width / 2,  origin.y + this.height),        Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(origin.x,                   origin.y + this.height / 2),    Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Rect): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         const snappableVectors: Array<Vector> = [];
 
         // Center, upper center, left center, lower center, right center
-        snappableVectors.push(Utilities.transform(new Vector(0, 0), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width, 0), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width, this.height), svg));
-        snappableVectors.push(Utilities.transform(new Vector(0, this.height / 2), svg));
-        snappableVectors.push(Utilities.transform(new Vector(this.width / 2, this.height / 2), svg));
+        snappableVectors.push(new Vector(origin.x, origin.y));
+        snappableVectors.push(new Vector(origin.x + this.width, origin.y));
+        snappableVectors.push(new Vector(origin.x + this.width, origin.y + this.height));
+        snappableVectors.push(new Vector(origin.x, origin.y + this.height / 2));
+        snappableVectors.push(new Vector(origin.x + this.width / 2, origin.y + this.height / 2));
 
         return snappableVectors;
     }

--- a/src/models/graphics/Sketch.ts
+++ b/src/models/graphics/Sketch.ts
@@ -48,8 +48,9 @@ export default class Sketch implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.PolyLine): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
         const boundingBox: SVG.RBox = svg.rbox();
         const width: number = boundingBox.width;
         const height: number = boundingBox.height;
@@ -65,7 +66,7 @@ export default class Sketch implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.PolyLine): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Sketch.ts
+++ b/src/models/graphics/Sketch.ts
@@ -48,25 +48,22 @@ export default class Sketch implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
-        const boundingBox: SVG.RBox = svg.rbox();
-        const width: number = boundingBox.width;
-        const height: number = boundingBox.height;
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, this.origin,   Vector.right));
+        snapVectors.push(new SnapVector(this.id, this.origin,   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(this.origin);
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/Sketch.ts
+++ b/src/models/graphics/Sketch.ts
@@ -64,4 +64,8 @@ export default class Sketch implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.PolyLine): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Text.ts
+++ b/src/models/graphics/Text.ts
@@ -65,4 +65,8 @@ export default class Text implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.Text): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Text.ts
+++ b/src/models/graphics/Text.ts
@@ -50,8 +50,9 @@ export default class Text implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(svg: SVG.Text): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
         const width: number = svg.width();
         const height: number = svg.height();
 
@@ -66,7 +67,7 @@ export default class Text implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Text): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Text.ts
+++ b/src/models/graphics/Text.ts
@@ -50,24 +50,22 @@ export default class Text implements IGraphic {
             .rotate(this.rotation);
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
-        const width: number = svg.width();
-        const height: number = svg.height();
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width, height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(width / 2, height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, this.origin,   Vector.right));
+        snapVectors.push(new SnapVector(this.id, this.origin,   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(this.origin);
+
+        return snappableVectors;
     }
 }

--- a/src/models/graphics/Video.ts
+++ b/src/models/graphics/Video.ts
@@ -78,4 +78,8 @@ export default class Video implements IGraphic {
 
         return snapVectors;
     }
+
+    public getSnappableVectors(svg: SVG.Bare): Array<Vector> {
+        return [];
+    }
 }

--- a/src/models/graphics/Video.ts
+++ b/src/models/graphics/Video.ts
@@ -65,8 +65,9 @@ export default class Video implements IGraphic {
         video.height = boundingRect.height;
     }
 
-    public getSnapVectors(svg: SVG.Bare): Array<SnapVector> {
+    public getSnapVectors(origin: Vector): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
+        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
         snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
@@ -79,7 +80,7 @@ export default class Video implements IGraphic {
         return snapVectors;
     }
 
-    public getSnappableVectors(svg: SVG.Bare): Array<Vector> {
+    public getSnappableVectors(origin: Vector): Array<Vector> {
         return [];
     }
 }

--- a/src/models/graphics/Video.ts
+++ b/src/models/graphics/Video.ts
@@ -65,22 +65,30 @@ export default class Video implements IGraphic {
         video.height = boundingRect.height;
     }
 
-    public getSnapVectors(origin: Vector): Array<SnapVector> {
+    public getSnapVectors(): Array<SnapVector> {
         const snapVectors: Array<SnapVector> = [];
-        const svg: any = {};
 
         // Center, upper center, left center, lower center, right center
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, 0), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width, this.height / 2), svg), Vector.up));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(this.width / 2, this.height), svg), Vector.right));
-        snapVectors.push(new SnapVector(this.id, Utilities.transform(new Vector(0, this.height / 2), svg), Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y),                     Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width,     this.origin.y + this.height / 2),   Vector.up));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x + this.width / 2, this.origin.y + this.height),       Vector.right));
+        snapVectors.push(new SnapVector(this.id, new Vector(this.origin.x,                  this.origin.y + this.height / 2),   Vector.up));
 
         return snapVectors;
     }
 
-    public getSnappableVectors(origin: Vector): Array<Vector> {
-        return [];
+    public getSnappableVectors(): Array<Vector> {
+        const snappableVectors: Array<Vector> = [];
+
+        // Center, upper center, left center, lower center, right center
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y));
+        snappableVectors.push(new Vector(this.origin.x + this.width,        this.origin.y + this.height));
+        snappableVectors.push(new Vector(this.origin.x,                     this.origin.y + this.height / 2));
+        snappableVectors.push(new Vector(this.origin.x + this.width / 2,    this.origin.y + this.height / 2));
+
+        return snappableVectors;
     }
 }

--- a/src/models/tools/CursorTool.ts
+++ b/src/models/tools/CursorTool.ts
@@ -76,7 +76,6 @@ export default class CursorTool implements ICanvasTool {
 
             // Preview moving shape
             function preview(event: Event): void {
-                graphic!.origin = Utilities.getPosition(event as CustomEvent, slideWrapper).add(cursorOffset);
 
                 const snapTranslations: Array<{ source: Vector, destination: SnapVector }> = [];
                 const snappableVectors: Array<Vector> = graphic!.getSnappableVectors(slideWrapper.getRenderedGraphic(graphic!.id));
@@ -103,7 +102,9 @@ export default class CursorTool implements ICanvasTool {
                         }
                     });
 
-                    // graphic!.origin = graphic!.origin.add(snapTranslation.destination.origin.add(snapTranslation.source.scale(-1)));
+                    graphic!.origin = Utilities.getPosition(event as CustomEvent, slideWrapper)
+                        .add(cursorOffset)
+                        .add(snapTranslation.source.towards(snapTranslation.destination.getClosestPoint(snapTranslation.source)));
 
                     c1.origin = snapTranslation.source.add(new Vector(-7.5, -7.5));
                     c2.origin = snapTranslation.destination.origin.add(new Vector(-7.5, -7.5));
@@ -112,6 +113,7 @@ export default class CursorTool implements ICanvasTool {
                 } else {
                     c1.origin = new Vector(-7.5, -7.5);
                     c2.origin = new Vector(-7.5, -7.5);
+                    graphic!.origin = Utilities.getPosition(event as CustomEvent, slideWrapper).add(cursorOffset);
                     slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c1.id, graphic: c1 });
                     slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c2.id, graphic: c2 });
                 }

--- a/src/models/tools/CursorTool.ts
+++ b/src/models/tools/CursorTool.ts
@@ -51,11 +51,6 @@ export default class CursorTool implements ICanvasTool {
 
     public graphicMouseDown(slideWrapper: SlideWrapper): (event: CustomEvent) => void {
         this.noop();
-        const c1: Ellipse = new Ellipse({ origin: new Vector(-7.5, -7.5), fillColor: "red", strokeColor: "none", width: 15, height: 15 });
-        const c2: Ellipse = new Ellipse({ origin: new Vector(-7.5, -7.5), fillColor: "purple", strokeColor: "none", width: 15, height: 15 });
-        slideWrapper.store.commit("addGraphic", { slideId: slideWrapper.slideId, graphic: c1 });
-        slideWrapper.store.commit("addGraphic", { slideId: slideWrapper.slideId, graphic: c2 });
-
         return function (event: CustomEvent): void {
             const graphic: IGraphic | undefined = slideWrapper.store.getters.graphic(slideWrapper.slideId, event.detail.graphicId);
             if (graphic === undefined) {
@@ -78,7 +73,7 @@ export default class CursorTool implements ICanvasTool {
             function preview(event: Event): void {
 
                 const snapTranslations: Array<{ source: Vector, destination: SnapVector }> = [];
-                const snappableVectors: Array<Vector> = graphic!.getSnappableVectors(slideWrapper.getRenderedGraphic(graphic!.id));
+                const snappableVectors: Array<Vector> = graphic!.getSnappableVectors(Utilities.getPosition(event as CustomEvent, slideWrapper).add(cursorOffset));
                 snapVectors.forEach((snapVector: SnapVector): void => {
                     // Find the closest snappable vector
                     const snapTranslation: { source: Vector, destination: SnapVector } = { source: snappableVectors[0], destination: snapVector };
@@ -105,17 +100,8 @@ export default class CursorTool implements ICanvasTool {
                     graphic!.origin = Utilities.getPosition(event as CustomEvent, slideWrapper)
                         .add(cursorOffset)
                         .add(snapTranslation.source.towards(snapTranslation.destination.getClosestPoint(snapTranslation.source)));
-
-                    c1.origin = snapTranslation.source.add(new Vector(-7.5, -7.5));
-                    c2.origin = snapTranslation.destination.origin.add(new Vector(-7.5, -7.5));
-                    slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c1.id, graphic: c1 });
-                    slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c2.id, graphic: c2 });
                 } else {
-                    c1.origin = new Vector(-7.5, -7.5);
-                    c2.origin = new Vector(-7.5, -7.5);
                     graphic!.origin = Utilities.getPosition(event as CustomEvent, slideWrapper).add(cursorOffset);
-                    slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c1.id, graphic: c1 });
-                    slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c2.id, graphic: c2 });
                 }
 
                 // Update the graphic and refresh focus to update bounding box
@@ -130,7 +116,7 @@ export default class CursorTool implements ICanvasTool {
                 document.removeEventListener("Deck.GraphicMouseUp", end);
 
                 // Add the new SnapVectors once the graphic move has been finalized
-                slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.slideId, snapVectors: graphic!.getSnapVectors(slideWrapper.getRenderedGraphic(graphic!.id)) });
+                slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.slideId, snapVectors: graphic!.getSnapVectors(Utilities.getPosition(event, slideWrapper).add(cursorOffset)) });
 
                 slideWrapper.store.commit("styleEditorObject", undefined);
                 slideWrapper.store.commit("styleEditorObject", graphic);

--- a/src/models/tools/CursorTool.ts
+++ b/src/models/tools/CursorTool.ts
@@ -103,6 +103,8 @@ export default class CursorTool implements ICanvasTool {
                         }
                     });
 
+                    // graphic!.origin = graphic!.origin.add(snapTranslation.destination.origin.add(snapTranslation.source.scale(-1)));
+
                     c1.origin = snapTranslation.source.add(new Vector(-7.5, -7.5));
                     c2.origin = snapTranslation.destination.origin.add(new Vector(-7.5, -7.5));
                     slideWrapper.store.commit("updateGraphic", { slideId: slideWrapper.slideId, graphicId: c1.id, graphic: c1 });

--- a/src/models/tools/RectangleTool.ts
+++ b/src/models/tools/RectangleTool.ts
@@ -63,9 +63,7 @@ export default class RectangleTool implements ICanvasTool {
 
                 slideWrapper.store.commit("focusGraphic", { slideId: slideWrapper.store.getters.activeSlide.id, graphicId: rectangle.id });
                 slideWrapper.store.commit("styleEditorObject", rectangle);
-
-                const snapVectors: Array<SnapVector> = rectangle.getSnapVectors(rectangle.origin);
-                slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.store.getters.activeSlide.id, snapVectors: snapVectors });
+                slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.store.getters.activeSlide.id, snapVectors: rectangle.getSnapVectors() });
             }
 
             function toggleSquare(event: KeyboardEvent): void {

--- a/src/models/tools/RectangleTool.ts
+++ b/src/models/tools/RectangleTool.ts
@@ -3,6 +3,7 @@ import Rectangle from "../graphics/Rectangle";
 import Vector from "../Vector";
 import SlideWrapper from "../../utilities/SlideWrapper";
 import Utilities from "../../utilities/general";
+import SnapVector from "../SnapVector";
 
 export default class RectangleTool implements ICanvasTool {
     public name: string;
@@ -62,6 +63,9 @@ export default class RectangleTool implements ICanvasTool {
 
                 slideWrapper.store.commit("focusGraphic", { slideId: slideWrapper.store.getters.activeSlide.id, graphicId: rectangle.id });
                 slideWrapper.store.commit("styleEditorObject", rectangle);
+
+                const snapVectors: Array<SnapVector> = rectangle.getSnapVectors(slideWrapper.getRenderedGraphic(rectangle.id));
+                slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.store.getters.activeSlide.id, snapVectors: snapVectors });
             }
 
             function toggleSquare(event: KeyboardEvent): void {

--- a/src/models/tools/RectangleTool.ts
+++ b/src/models/tools/RectangleTool.ts
@@ -64,7 +64,7 @@ export default class RectangleTool implements ICanvasTool {
                 slideWrapper.store.commit("focusGraphic", { slideId: slideWrapper.store.getters.activeSlide.id, graphicId: rectangle.id });
                 slideWrapper.store.commit("styleEditorObject", rectangle);
 
-                const snapVectors: Array<SnapVector> = rectangle.getSnapVectors(slideWrapper.getRenderedGraphic(rectangle.id));
+                const snapVectors: Array<SnapVector> = rectangle.getSnapVectors(rectangle.origin);
                 slideWrapper.store.commit("addSnapVectors", { slideId: slideWrapper.store.getters.activeSlide.id, snapVectors: snapVectors });
             }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -35,6 +35,7 @@ type State = {
 type Getters = {
     slides: (state: State) => Array<Slide>,
     graphic: (state: State) => (slideId: string, graphicId: string) => IGraphic | undefined,
+    snapVectors: (state: State) => (slideId: string) => Array<SnapVector>,
     activeSlide: (state: State) => Slide | undefined,
     styleEditorObject: (state: State) => any,
     tool: (state: State) => ICanvasTool,
@@ -114,6 +115,17 @@ const store: {
                 }
 
                 return slide.graphics[index];
+            };
+        },
+        snapVectors: (state: State): ((slideId: string) => Array<SnapVector>) => {
+            return function(slideId: string): Array<SnapVector> {
+                const slide: Slide | undefined = state.slides.find((slide: Slide): boolean => slide.id === slideId);
+                if (slide === undefined) {
+                    console.error(`ERROR: No slide exists with id: ${slideId}`);
+                    return [];
+                }
+
+                return slide.snapVectors;
             };
         },
         activeSlide: (state: State): Slide | undefined => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -118,7 +118,7 @@ const store: {
             };
         },
         snapVectors: (state: State): ((slideId: string) => Array<SnapVector>) => {
-            return function(slideId: string): Array<SnapVector> {
+            return function (slideId: string): Array<SnapVector> {
                 const slide: Slide | undefined = state.slides.find((slide: Slide): boolean => slide.id === slideId);
                 if (slide === undefined) {
                     console.error(`ERROR: No slide exists with id: ${slideId}`);
@@ -257,6 +257,7 @@ const store: {
             }
 
             slide.snapVectors = slide.snapVectors.filter((snapVector: SnapVector): boolean => snapVector.graphicId !== graphicId);
+            // console.log("REMOVE:", slide.snapVectors.length);
         },
         addSnapVectors: (state: State, { slideId, snapVectors }: { slideId: string, snapVectors: Array<SnapVector> }): void => {
             const slide: Slide | undefined = state.slides.find((slide: Slide): boolean => slide.id === slideId);
@@ -266,6 +267,7 @@ const store: {
             }
 
             slide.snapVectors.push(...snapVectors);
+            // console.log("ADDED:", slide.snapVectors.length);
         }
     },
     actions: {

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ import PencilTool from "./models/tools/PencilTool";
 import PenTool from "./models/tools/PenTool";
 import RectangleTool from "./models/tools/RectangleTool";
 import TextboxTool from "./models/tools/TextboxTool";
+import Vector from "./models/Vector";
 
 type State = {
     activeSlideId: string,
@@ -156,11 +157,17 @@ const store: {
     },
     mutations: {
         addSlide: (state: State, index: number): void => {
-            if (state.slides.length === index) {
-                state.slides.push(new Slide());
-            } else {
-                state.slides.splice(index, 0, new Slide());
-            }
+            const slide: Slide = new Slide();
+            const width: number = state.canvas.resolution * 1072;
+            const height: number = state.canvas.resolution * 603;
+            slide.snapVectors.push(new SnapVector("slide", new Vector(width / 2, 0), Vector.right));
+            slide.snapVectors.push(new SnapVector("slide", new Vector(width, height / 2), Vector.up));
+            slide.snapVectors.push(new SnapVector("slide", new Vector(width / 2, height), Vector.right));
+            slide.snapVectors.push(new SnapVector("slide", new Vector(0, height / 2), Vector.up));
+            slide.snapVectors.push(new SnapVector("slide", new Vector(width / 2, height / 2), Vector.right));
+            slide.snapVectors.push(new SnapVector("slide", new Vector(width / 2, height / 2), Vector.up));
+
+            state.slides.splice(index, 0, slide);
         },
         reorderSlide: (state: State, { source, destination }: { source: number, destination: number }): void => {
             const slide: Slide = state.slides[source];
@@ -257,7 +264,6 @@ const store: {
             }
 
             slide.snapVectors = slide.snapVectors.filter((snapVector: SnapVector): boolean => snapVector.graphicId !== graphicId);
-            // console.log("REMOVE:", slide.snapVectors.length);
         },
         addSnapVectors: (state: State, { slideId, snapVectors }: { slideId: string, snapVectors: Array<SnapVector> }): void => {
             const slide: Slide | undefined = state.slides.find((slide: Slide): boolean => slide.id === slideId);
@@ -267,7 +273,6 @@ const store: {
             }
 
             slide.snapVectors.push(...snapVectors);
-            // console.log("ADDED:", slide.snapVectors.length);
         }
     },
     actions: {

--- a/test/SnapVector.spec.js
+++ b/test/SnapVector.spec.js
@@ -51,4 +51,30 @@ describe("SnapVector", () => {
         // Assert
         expect(actualDistance).toBe(expectedDistance);
     });
+
+    it("can calculate the distance from a point with a vertical direction", () => {
+        // Arrange
+        const snapVector = new SnapVector("", new Vector(0, 0), Vector.up);
+        const point = new Vector(1, 1);
+        const expectedDistance = 1;
+
+        // Act
+        const actualDistance = snapVector.distanceFromVector(point);
+
+        // Assert
+        expect(actualDistance).toBe(expectedDistance);
+    });
+
+    it("can calculate the distance from a point with a horizontal direction", () => {
+        // Arrange
+        const snapVector = new SnapVector("", new Vector(0, 0), Vector.right);
+        const point = new Vector(1, 1);
+        const expectedDistance = 1;
+
+        // Act
+        const actualDistance = snapVector.distanceFromVector(point);
+
+        // Assert
+        expect(actualDistance).toBe(expectedDistance);
+    });
 });

--- a/test/SnapVector.spec.js
+++ b/test/SnapVector.spec.js
@@ -28,19 +28,21 @@ describe("SnapVector", () => {
 
     it("can calculate the distance from a point with direction", () => {
         // Arrange
+        const epsilon = 1E-5;
         const snapVector = new SnapVector("", new Vector(3, 8), new Vector(1, -1));
         const point = new Vector(9, 3);
-        const expectedDistance = 1 / Math.SQRT2;
+        const expectedDistance = 1 / Math.sqrt(2);
 
         // Act
         const actualDistance = snapVector.distanceFromVector(point);
 
         // Assert
-        expect(actualDistance).toBe(expectedDistance);
+        expect(closeEnough(expectedDistance, actualDistance, epsilon)).toBe(true);
     });
 
-    it("can calculate the distance from a point along the vector", () => {
+    it("can calculate the distance from a point on the direction vector", () => {
         // Arrange
+        const epsilon = 1E-5;
         const snapVector = new SnapVector("", new Vector(3, 8), new Vector(1, -1));
         const point = new Vector(9, 2);
         const expectedDistance = 0;
@@ -49,7 +51,7 @@ describe("SnapVector", () => {
         const actualDistance = snapVector.distanceFromVector(point);
 
         // Assert
-        expect(actualDistance).toBe(expectedDistance);
+        expect(closeEnough(expectedDistance, actualDistance, epsilon)).toBe(true);
     });
 
     it("can calculate the distance from a point with a vertical direction", () => {
@@ -76,5 +78,75 @@ describe("SnapVector", () => {
 
         // Assert
         expect(actualDistance).toBe(expectedDistance);
+    });
+
+    it("can calculate the closest point from a point with no direction", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const snapVector = new SnapVector("", new Vector(2, 5));
+        const point = new Vector(-3, 7);
+        const expectedClosestPoint = new Vector(2, 5);
+
+        // Act
+        const actualClosestPoint = snapVector.getClosestPoint(point);
+
+        // Assert
+        expect(vectorsCloseEnough(expectedClosestPoint, actualClosestPoint, epsilon)).toBe(true);
+    });
+
+    it("can calculate the closest point from a point with direction", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const snapVector = new SnapVector("", new Vector(3, 8), new Vector(1, -1));
+        const point = new Vector(9, 3);
+        const expectedClosestPoint = new Vector(8.5, 2.5);
+
+        // Act
+        const actualClosestPoint = snapVector.getClosestPoint(point);
+
+        // Assert
+        expect(vectorsCloseEnough(expectedClosestPoint, actualClosestPoint, epsilon)).toBe(true);
+    });
+
+    it("can calculate the closest point from a point on the direction vector", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const snapVector = new SnapVector("", new Vector(3, 8), new Vector(1, -1));
+        const point = new Vector(9, 2);
+        const expectedClosestPoint = new Vector(9, 2);
+
+        // Act
+        const actualClosestPoint = snapVector.getClosestPoint(point);
+
+        // Assert
+        expect(vectorsCloseEnough(expectedClosestPoint, actualClosestPoint, epsilon)).toBe(true);
+    });
+
+    it("can calculate the closest point from a point with a vertical direction", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const snapVector = new SnapVector("", new Vector(2, 5), new Vector(0, 1));
+        const point = new Vector(-3, 7);
+        const expectedClosestPoint = new Vector(2, 7);
+
+        // Act
+        const actualClosestPoint = snapVector.getClosestPoint(point);
+
+        // Assert
+        expect(vectorsCloseEnough(expectedClosestPoint, actualClosestPoint, epsilon)).toBe(true);
+    });
+
+    it("can calculate the closest point from a point with a horizontal direction", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const snapVector = new SnapVector("", new Vector(2, 5), new Vector(1, 0));
+        const point = new Vector(-3, 7);
+        const expectedClosestPoint = new Vector(-3, 5);
+
+        // Act
+        const actualClosestPoint = snapVector.getClosestPoint(point);
+
+        // Assert
+        expect(vectorsCloseEnough(expectedClosestPoint, actualClosestPoint, epsilon)).toBe(true);
     });
 });

--- a/test/Vector.spec.js
+++ b/test/Vector.spec.js
@@ -1,0 +1,206 @@
+import Vector from "../src/models/Vector";
+
+describe("Vector", () => {
+    it("can calculate magnitude", () => {
+        // Arrange
+        const vector1 = new Vector(0, 0);
+        const vector2 = new Vector(2, 3);
+        const vector3 = new Vector(-4, 1);
+        const vector4 = new Vector(-5, -10);
+        const vector5 = new Vector(3, -2);
+        const expectedMagnitude1 = 0;
+        const expectedMagnitude2 = Math.sqrt(13);
+        const expectedMagnitude3 = Math.sqrt(17);
+        const expectedMagnitude4 = 5 * Math.sqrt(5);
+        const expectedMagnitude5 = Math.sqrt(13);
+        
+        // Act
+        const actualMagnitude1 = vector1.magnitude;
+        const actualMagnitude2 = vector2.magnitude;
+        const actualMagnitude3 = vector3.magnitude;
+        const actualMagnitude4 = vector4.magnitude;
+        const actualMagnitude5 = vector5.magnitude;
+
+        // Assert
+        expect(actualMagnitude1).toBe(expectedMagnitude1);
+        expect(actualMagnitude2).toBe(expectedMagnitude2);
+        expect(actualMagnitude3).toBe(expectedMagnitude3);
+        expect(actualMagnitude4).toBe(expectedMagnitude4);
+        expect(actualMagnitude5).toBe(expectedMagnitude5);
+    });
+
+    it("can normalize vectors", () => {
+        // Arrange
+        const vector1 = new Vector(0, 0);
+        const vector2 = new Vector(2, 3);
+        const vector3 = new Vector(-4, 1);
+        const vector4 = new Vector(-5, -10);
+        const vector5 = new Vector(3, -2);
+        const expectedNormal1 = new Vector(0, 0);
+        const expectedNormal2 = new Vector(2 / Math.sqrt(13), 3 / Math.sqrt(13));
+        const expectedNormal3 = new Vector(-4 / Math.sqrt(17), 1 / Math.sqrt(17));
+        const expectedNormal4 = new Vector(-1 / Math.sqrt(5), -2 / Math.sqrt(5));
+        const expectedNormal5 = new Vector(3 / Math.sqrt(13), -2 / Math.sqrt(13));
+        
+        // Act
+        const actualNormal1 = vector1.normalized;
+        const actualNormal2 = vector2.normalized;
+        const actualNormal3 = vector3.normalized;
+        const actualNormal4 = vector4.normalized;
+        const actualNormal5 = vector5.normalized;
+
+        // Assert
+        expect(actualNormal1).toEqual(expectedNormal1);
+        expect(actualNormal2).toEqual(expectedNormal2);
+        expect(actualNormal3).toEqual(expectedNormal3);
+        expect(actualNormal4).toEqual(expectedNormal4);
+        expect(actualNormal5).toEqual(expectedNormal5);
+    });
+
+    it("can convert vectors to arrays", () => {
+        // Arrange
+        const vector1 = new Vector(0, 0);
+        const vector2 = new Vector(2, 3);
+        const vector3 = new Vector(-4, 1);
+        const vector4 = new Vector(-5, -10);
+        const vector5 = new Vector(3, -2);
+        const expectedArray1 = [0, 0];
+        const expectedArray2 = [2, 3];
+        const expectedArray3 = [-4, 1];
+        const expectedArray4 = [-5, -10];
+        const expectedArray5 = [3, -2];
+        
+        // Act
+        const actualArray1 = vector1.array;
+        const actualArray2 = vector2.array;
+        const actualArray3 = vector3.array;
+        const actualArray4 = vector4.array;
+        const actualArray5 = vector5.array;
+
+        // Assert
+        expect(actualArray1).toEqual(expectedArray1);
+        expect(actualArray2).toEqual(expectedArray2);
+        expect(actualArray3).toEqual(expectedArray3);
+        expect(actualArray4).toEqual(expectedArray4);
+        expect(actualArray5).toEqual(expectedArray5);
+    });
+
+    it("can calculate the sum vectors", () => {
+        // Arrange
+        const vector1 = new Vector(-3, 4);
+        const vector2 = new Vector(2, 3);
+        const expectedSum = new Vector(-1, 7);
+        
+        // Act
+        const actualSum = vector1.add(vector2);
+
+        // Assert
+        expect(actualSum).toEqual(expectedSum);
+    });
+
+    it("can calculate the difference between two vectors", () => {
+        // Arrange
+        const vector1 = new Vector(-3, 4);
+        const vector2 = new Vector(2, 3);
+        const expectedDifference = new Vector(-5, 1);
+        
+        // Act
+        const actualDifference = vector2.towards(vector1);
+
+        // Assert
+        expect(actualDifference).toEqual(expectedDifference);
+    });
+
+    it("can calculate the dot product of two vectors", () => {
+        // Arrange
+        const vector1 = new Vector(-3, 4);
+        const vector2 = new Vector(2, 3);
+        const expectedDotProduct = 6;
+        
+        // Act
+        const actualDotProduct = vector1.dot(vector2);
+
+        // Assert
+        expect(actualDotProduct).toBe(expectedDotProduct);
+    });
+
+    it("can calculate the angle between two vectors (in radians)", () => {
+        // Arrange
+        const epsilon = 1E-5;
+        const vector1 = new Vector(2, 0);
+        const vector2 = new Vector(5, 5);
+        const expectedAngle = Math.PI / 4;
+        
+        // Act
+        const actualAngle = vector1.theta(vector2);
+
+        // Assert
+        expect(closeEnough(actualAngle, expectedAngle, epsilon)).toBe(true);
+    });
+
+    it("can calculate the projection of one vector onto another", () => {
+        // Arrange
+        const vector1 = new Vector(2, 0);
+        const vector2 = new Vector(5, 5);
+        const expectedProjection = new Vector(5, 0);
+        
+        // Act
+        const actualProjection = vector2.projectOn(vector1);
+
+        // Assert
+        expect(actualProjection).toEqual(expectedProjection);
+    });
+
+    it("can scale vectors", () => {
+        // Arrange
+        const vector = new Vector(2, -3);
+        const scalar = 3;
+        const expectedScaledVector = new Vector(6, -9);
+        
+        // Act
+        const actualScaledVector = vector.scale(scalar);
+
+        // Assert
+        expect(actualScaledVector).toEqual(expectedScaledVector);
+    });
+
+    it("can reflect a vector over itself", () => {
+        // Arrange
+        const vector = new Vector(2, -3);
+        const expectedReflectedVector = new Vector(2, -3);
+        
+        // Act
+        const actualReflectedVector = vector.reflect();
+
+        // Assert
+        expect(actualReflectedVector).toEqual(expectedReflectedVector);
+    });
+
+    it("can reflect a vector over an arbitrary origin vector", () => {
+        // Arrange
+        const vector = new Vector(2, -3);
+        const origin = new Vector(-1, 2)
+        const expectedReflectedVector = new Vector(-4, 7);
+        
+        // Act
+        const actualReflectedVector = vector.reflect(origin);
+
+        // Assert
+        expect(actualReflectedVector).toEqual(expectedReflectedVector);
+    });
+
+    it("can check for equal vectors", () => {
+        // Arrange
+        const vector1 = new Vector(2, -3);
+        const vector2 = new Vector(2, -3);
+        const vector3 = new Vector(-1, 5);
+        
+        // Act
+        const firstEqual = vector1.equals(vector2);
+        const secondEqual = vector2.equals(vector3);
+
+        // Assert
+        expect(firstEqual).toBe(true);
+        expect(secondEqual).toBe(false);
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,11 @@
 require("jsdom-global")();
 global.expect = require("expect");
 global.FileReader = window.FileReader;
+
+global.closeEnough = function(a, b, epsilon) {
+    return Math.abs(a - b) < epsilon;
+}
+
+global.vectorsCloseEnough = function(v1, v2, epsilon) {
+    return closeEnough(v1.x, v2.x, epsilon) && closeEnough(v1.y, v2.y, epsilon);
+}


### PR DESCRIPTION
This pull request adds the `SnappableVector` model which represents the points on a graphic that can be snapped to a `SnapVector`. Furthermore, graphics now snap to each other and to defined slide constants.

Closes #58 